### PR TITLE
doc: adding license, contributor info, changed author, improved Readme

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,42 @@
+Contributor Code of Conduct
+================================================================================
+
+As contributors and maintainers of this project, and in the interest of
+fostering an open and welcoming community, we pledge to respect all people who
+contribute through reporting issues, posting feature requests, updating
+documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free
+experience for everyone, regardless of level of experience, gender, gender
+identity and expression, sexual orientation, disability, personal appearance,
+body size, race, ethnicity, age, religion, citizenship or national origin.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic
+  addresses, without explicit permission
+* Other unethical or unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct. By adopting this Code of Conduct, project
+maintainers commit themselves to fairly and consistently applying these
+principles to every aspect of managing this project. Project maintainers who do
+not follow or enforce this Code of Conduct may be permanently removed from the
+project team.
+
+This Code of Conduct applies both within project spaces and outside of project spaces
+when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by opening an issue or contacting one or more of the project
+maintainers.
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](http://contributor-covenant.org),
+version 1.2.0, available at
+<http://contributor-covenant.org/version/1/2/0/>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+Contributing
+================================================================================
+
+Awesome!  We're happy that you want to contribute.
+
+Make sure that you're read and understand the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+
+Building from source
+--------------------------------------------------------------------------------
+
+There are no special instructions to build this project, other than to
+run `npm install` after cloning the repo, to get all the dependent packages
+installed.
+
+After making changes, you should run `npm test` to ensure all the tests
+currently pass.  If you are adding or changing function, you should add tests
+in either an existing test module or a new one.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,23 @@
+The MIT License (MIT)
+=====================
+
+Copyright (c) 2016 NodeSource
+-----------------------------
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Iterates through all the persistent handles in the current isolate's heap that have class_ids and returns the ones matching specific class_id.
 
+## Installation
+
+    npm install persistents-with-classid
+
+## Example
+
 ```js
 const persistents = require('persistents-with-classid');
 
@@ -65,35 +71,7 @@ inspect(result, 3);
        msecs: 30 } ] }
 ```
 
-## Async Wrap Providers
-
-**NOTE**: that these got updated after `v4.1.1` and are still pending a release
-
-```js
-{ NONE: 0,
-  CRYPTO: 1,
-  FSEVENTWRAP: 2,
-  FSREQWRAP: 3,
-  GETADDRINFOREQWRAP: 4,
-  GETNAMEINFOREQWRAP: 5,
-  JSSTREAM: 6,
-  PIPEWRAP: 7,
-  PIPECONNECTWRAP: 8,
-  PROCESSWRAP: 9,
-  QUERYWRAP: 10,
-  SHUTDOWNWRAP: 11,
-  SIGNALWRAP: 12,
-  STATWATCHER: 13,
-  TCPWRAP: 14,
-  TCPCONNECTWRAP: 15,
-  TIMERWRAP: 16,
-  TLSWRAP: 17,
-  TTYWRAP: 18,
-  UDPWRAP: 19,
-  UDPSENDWRAP: 20,
-  WRITEWRAP: 21,
-  ZLIB: 22 }
-```
+## API
 
 <!-- START docme generated API please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN docme TO UPDATE -->
@@ -222,6 +200,59 @@ with signature: <code>callback(classid, object)</code></p></td>
 </div>
 <!-- END docme generated API please keep comment here to allow auto update -->
 
-## LICENSE
+## Async Wrap Providers
 
-MIT
+```js
+{ NONE: 0,
+  CRYPTO: 1,
+  FSEVENTWRAP: 2,
+  FSREQWRAP: 3,
+  GETADDRINFOREQWRAP: 4,
+  GETNAMEINFOREQWRAP: 5,
+  JSSTREAM: 6,
+  PIPEWRAP: 7,
+  PIPECONNECTWRAP: 8,
+  PROCESSWRAP: 9,
+  QUERYWRAP: 10,
+  SHUTDOWNWRAP: 11,
+  SIGNALWRAP: 12,
+  STATWATCHER: 13,
+  TCPWRAP: 14,
+  TCPCONNECTWRAP: 15,
+  TIMERWRAP: 16,
+  TLSWRAP: 17,
+  TTYWRAP: 18,
+  UDPWRAP: 19,
+  UDPSENDWRAP: 20,
+  WRITEWRAP: 21,
+  ZLIB: 22 }
+```
+ 
+## Contributing
+
+To submit a bug report, please create an [issue at GitHub][].
+
+If you'd like to contribute code to this project, please read the
+[CONTRIBUTING.md][] document.
+
+## Authors and Contributors
+
+<table><tbody>
+  <tr>
+    <th align="left">Thorsten Lorenz</th>
+    <td><a href="https://github.com/thlorenz">GitHub/thlorenz</a></td>
+    <td><a href="https://twitter.com/thlorenz">Twitter/@thlorenz</a></td>
+  </tr>
+</tbody></table>
+
+
+## License & Copyright
+
+**persistents-with-classid** is Copyright (c) 2016 NodeSource and licensed under the
+MIT license. All rights not explicitly granted in the MIT license are reserved.
+See the included [LICENSE.md][] file for more details.
+
+
+[issue at GitHub]: https://github.com/nodesource/persistents-with-classid/issues
+[CONTRIBUTING.md]: CONTRIBUTING.md
+[LICENSE.md]: LICENSE.md

--- a/package.json
+++ b/package.json
@@ -21,14 +21,16 @@
   },
   "keywords": [],
   "author": {
+    "name": "NodeSource",
+    "email": "npm@nodesource.com",
+    "url": "https://nodesource.com"
+  },
+  "contributors": [ {
     "name": "Thorsten Lorenz",
     "email": "thlorenz@gmx.de",
     "url": "http://thlorenz.com"
-  },
-  "license": {
-    "type": "MIT",
-    "url": "https://github.com/nodesource/persistents-with-classid/blob/master/LICENSE"
-  },
+  } ],
+  "license": "MIT",
   "engine": {
     "node": ">=0.12"
   }


### PR DESCRIPTION
- adapted to be mostly similar to [statsd repo](https://github.com/nodesource/nsolid-statsd)
- kept example on top though as that is more descriptive than the API doc itself

View the updated version [here](https://github.com/nodesource/persistents-with-classid/tree/thlorenz/open-source)

Also please LMK how I should go about publishing this to npm, i.e. under my account or somehow under the nodesource account (need access to that).

cc @rvagg @kstewart 
