### PR TITLE
core: transferring handles to JS after visit is done

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "persistents-with-classid",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Iterates through all the persistent handles in the current isolate's heap that have class_ids and returns the ones matching specific class_id",
   "main": "persistents-with-classid.js",
   "scripts": {

--- a/src/persistents_with_classid.cc
+++ b/src/persistents_with_classid.cc
@@ -68,6 +68,9 @@ class PersistentHandleWithClassIdVisitor : public PersistentHandleVisitor {
 
     ~PersistentHandleWithClassIdVisitor() {
       fn_p_.Reset();
+      for (auto h : handles_) {
+        delete h;
+      }
       handles_.clear();
     }
 

--- a/test/checks.js
+++ b/test/checks.js
@@ -1,0 +1,46 @@
+'use strict'
+
+const test = require('tape').test
+const persistents = require('../')
+const provider = require('./util/get-provider')('TIMERWRAP')
+const idleNext = require('./util/compat').idleNext
+const TIMEOUT = 20
+
+function ontimeout() {}
+
+function withMsecs(ms) {
+  return function filter(x) {
+    return (x.msecs || x._list.msecs) === ms
+  }
+}
+
+function ensurePersistent(t, timer, msecs) {
+  t.ok(timer, 'includes timer')
+  t.equal(idleNext(timer)._onTimeout, undefined, 'no longer refers to user callback')
+  t.end()
+}
+
+function checkAfterCleared(t, timer, msecs) {
+  // the timer should be collectable at this point, so we wait until it's no longer
+  // part of the persitents maintained by v8
+
+  const currentRes = persistents.collect()
+  if (!currentRes[provider]) return ensurePersistent(t, timer, msecs)
+
+  // timer still part of active handles, wait for it to dissappear
+  for (var i = 0; i < msecs.length; i++) {
+    const timers = currentRes[provider].filter(withMsecs(msecs[i]))
+    if (timers.length) return setImmediate(checkAfterCleared.bind(null, t, timer, msecs))
+  }
+}
+
+test('\ngiven one setTimeout, accessing persistents on other event loop', function(t) {
+  setTimeout(ontimeout, TIMEOUT)
+
+  setImmediate(runTest)
+  function runTest() {
+    const res = persistents.collect()
+    const timer = res[provider].filter(withMsecs(TIMEOUT))[0]
+    checkAfterCleared(t, timer, [ TIMEOUT ])
+  }
+})

--- a/test/util/compat.js
+++ b/test/util/compat.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const major = require('./node-major')
+const minor = require('./node-minor')
 const async_wrap = process.binding('async_wrap')
 
 // node compatibility convenience functions
@@ -20,7 +21,8 @@ function adaptInit (init) {
   function adaptedInit (p) {
     return init('__adapted id__', p)
   }
-  if (major.le4) return adaptedInit
+  // node 4.5 has backported async_wrap changes
+  if (major.le4 && minor.minor < 5) return adaptedInit
   return init
 }
 
@@ -28,9 +30,9 @@ function noop () {}
 // we are using the node v6 API as much as we can with supported ES6 in v4, but in case
 // we run with v4 we adapt the call to the setupHooks function
 exports.setupHooks = function setupHooks (init) {
-  if (major.le4) {
+  if (major.le4 && minor.minor < 5) {
     async_wrap.setupHooks(adaptInit(init), noop, noop)
-  } else if (major.ge6) {
+  } else if (major.le6) {
     async_wrap.setupHooks({ init })
   }
 }

--- a/test/util/node-minor.js
+++ b/test/util/node-minor.js
@@ -1,0 +1,1 @@
+exports.minor = parseInt(process.version[3])


### PR DESCRIPTION
- reason is that during the heap walk we cannot alloc anything in JS
  land
- however with the previous version this occurred at in Debug mode
  causing the process to crash
- now we collect all info in a C++ vector and when the heap walk is
  done, we iterate over the items in the vector and call into JS with
  each of them
- converting to Object as soon as we verified it
- using persistent object pointer to store the handle

cc @cxreg @trevnorris 