### PR TITLE
core: PersistentHandleWithClassId allocated with new must be deleted

### DIFF
--- a/src/persistents_with_classid.cc
+++ b/src/persistents_with_classid.cc
@@ -68,6 +68,9 @@ class PersistentHandleWithClassIdVisitor : public PersistentHandleVisitor {
 
     ~PersistentHandleWithClassIdVisitor() {
       fn_p_.Reset();
+      for (auto h : handles_) {
+        delete h;
+      }
       handles_.clear();
     }
 


### PR DESCRIPTION
Found this with Valgrind, and confirmed that with the delete that it doesn't leak.  The vector::clear will remove the pointers but will not call delete on its members